### PR TITLE
Adding spaces support to load-test spaces at scale

### DIFF
--- a/Console/Commands/SpaceCommand.cs
+++ b/Console/Commands/SpaceCommand.cs
@@ -1,0 +1,22 @@
+﻿using Octopus.Client;
+using SeaMonkey.Monkeys;
+
+namespace SeaMonkey.Commands
+{
+    public class SpaceCommand : IMonkeyCommand
+    {
+        private readonly OctopusRepository _repository;
+        public int NumberOfSpaces { get; set; } = 5;
+
+        public SpaceCommand(OctopusRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public void Run()
+        {
+            var spaceMonkey = new SpaceMonkey(_repository);
+            spaceMonkey.Create(NumberOfSpaces);
+        }
+    }
+}

--- a/Console/MonkeyBreed.cs
+++ b/Console/MonkeyBreed.cs
@@ -10,6 +10,7 @@ namespace SeaMonkey
         Configuration = 6,
         Library = 7,
         CreateVariables = 8,
-        CleanupVariables = 9
+        CleanupVariables = 9,
+        Spaces = 10
     }
 }

--- a/Console/MonkeyCommandFactory.cs
+++ b/Console/MonkeyCommandFactory.cs
@@ -30,6 +30,7 @@ namespace SeaMonkey
                 MonkeyBreed.RunbookRun => new RunbookRunCommand(_repository),
                 MonkeyBreed.Setup => new SetupCommand(_repository),
                 MonkeyBreed.Tenant => new TenantCommand(_repository),
+                MonkeyBreed.Spaces => new SpaceCommand(_repository),
                 _ => throw new ArgumentOutOfRangeException()
             };
             return command;

--- a/Console/Monkeys/SpaceMonkey.cs
+++ b/Console/Monkeys/SpaceMonkey.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using Octopus.Client;
+using Octopus.Client.Model;
+using Serilog;
+
+namespace SeaMonkey.Monkeys
+{
+    public class SpaceMonkey : Monkey
+    {
+        public SpaceMonkey(OctopusRepository repository) : base(repository)
+        {
+        }
+
+        public void Create(int numberOfRecords)
+        {
+            Log.Information("Creating {n} spaces", numberOfRecords);
+
+            Enumerable.Range(1, numberOfRecords)
+                .AsParallel()
+                .ForAll(i => {
+                    var name = "Space " + i.ToString("000");
+                    var resource = Repository.Spaces.FindByName(name);
+                    if (resource is not null)
+                    {
+                        Log.Information("Space {name} already exists. Skipping.", name);
+                        return;
+                    }
+
+                    Repository.Spaces.Create(new SpaceResource()
+                    {
+                        Name = name,
+                        SpaceManagersTeams = new ReferenceCollection("teams-administrators") // Give all admins access to new spaces.
+                    });
+                    Log.Information("Created space {name}", name);
+                });
+        }
+    }
+}

--- a/Console/TroopRequest.cs
+++ b/Console/TroopRequest.cs
@@ -24,7 +24,7 @@ namespace SeaMonkey
 
             if (monkeyBreeds.IsNullOrEmpty())
                 throw new InvalidTroopRequestException(
-                    "No monkeys were specified. Please use one of the following flags to run a monkey: --runSetupMonkey --runTenantMonkey --runDeployMonkey --runConfigurationMonkey --runInfrastructureMonkey --runLibraryMonkey --runVariablesMonkey");
+                    "No monkeys were specified. Please use one of the following flags to run a monkey: --runSetupMonkey --runTenantMonkey --runDeployMonkey --runConfigurationMonkey --runInfrastructureMonkey --runLibraryMonkey --runVariablesMonkey --runSpacesMonkey");
 
             ServerAddress = serverAddress;
             ApiKey = apiKey;

--- a/Console/TroopRequestParser.cs
+++ b/Console/TroopRequestParser.cs
@@ -53,6 +53,9 @@ namespace SeaMonkey
             options.Add<string>("runVariablesMonkey", "",
                 e => requestBuilder.WithMonkeyBreed(MonkeyBreed.CreateVariables));
 
+            options.Add<string>("runSpacesMonkey", "",
+                e => requestBuilder.WithMonkeyBreed(MonkeyBreed.Spaces));
+
             options.Parse(args);
 
             return requestBuilder.Build();


### PR DESCRIPTION
I needed to test spaces at scale, loading up 2000+ spaces to see limitations of some of our central queries.

This adds support for `runSpacesMonkey` to SeaMonkey.

The default is set to 5, so this won't go crazy if people go poking around here :)